### PR TITLE
Fixed item already added exception

### DIFF
--- a/src/ServiceFabric.Remoting.CustomHeaders/ExtendedServiceRemotingClientFactory.cs
+++ b/src/ServiceFabric.Remoting.CustomHeaders/ExtendedServiceRemotingClientFactory.cs
@@ -146,7 +146,11 @@ namespace ServiceFabric.Remoting.CustomHeaders
             {
                 var header = requestMessage.GetHeader();
                 var customHeaders = CreateCustomHeaders();
-                customHeaders.Add(CustomHeaders.ReservedHeaderServiceUri, ResolvedServicePartition.ServiceName);
+
+                if (!customHeaders.ContainsKey(CustomHeaders.ReservedHeaderServiceUri))
+                {
+                    customHeaders.Add(CustomHeaders.ReservedHeaderServiceUri, ResolvedServicePartition.ServiceName);
+                }
 
                 if (!header.TryGetHeaderValue(CustomHeaders.CustomHeader, out var headerValue))
                     header.AddHeader(CustomHeaders.CustomHeader, customHeaders.Serialize());
@@ -172,7 +176,7 @@ namespace ServiceFabric.Remoting.CustomHeaders
                     if (afterSendRequestResponseAsync != null)
                         await afterSendRequestResponseAsync.Invoke(new ServiceResponseInfo(responseMessage, header.MethodName, ResolvedServicePartition.ServiceName, state, exception));
                 }
-                
+
                 return responseMessage;
             }
 

--- a/src/ServiceFabric.Remoting.CustomHeaders/ServiceFabric.Remoting.CustomHeaders.csproj
+++ b/src/ServiceFabric.Remoting.CustomHeaders/ServiceFabric.Remoting.CustomHeaders.csproj
@@ -19,10 +19,10 @@ RemotingContext
 ExtendedServiceRemotingClientFactory
 ExtendedActorService</Description>
     <Company></Company>
-    <Version>3.0.8</Version>
+    <Version>3.0.9</Version>
     <PackageReleaseNotes>Include xml docs</PackageReleaseNotes>
-    <AssemblyVersion>3.0.8.0</AssemblyVersion>
-    <FileVersion>3.0.8.0</FileVersion>
+    <AssemblyVersion>3.0.9.0</AssemblyVersion>
+    <FileVersion>3.0.9.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="DemoActor.Interfaces\**" />


### PR DESCRIPTION
This exception "An item with the same key has already been added. Key: x-fabric-service" was thrown when trying to use same service instance to invoke multiple methods.